### PR TITLE
Corrección del fallo al registrar un usuario

### DIFF
--- a/app/functions.py
+++ b/app/functions.py
@@ -125,6 +125,7 @@ def addnewuser(v_user, v_password, v_name, v_mail, v_date, v_ipdonald, v_ipmicke
  setcoockie('s_user',v_user)
  setcoockie('s_password',v_password)
  setcoockie('s_name', v_name)
+ setcoockie('s_role', '2')
  redirect('/dashboard')
 
 def newuser_createrole(v_user, v_password):


### PR DESCRIPTION
Cuando creaba un usuario no creaba la cookie con el rol, por lo que cuando redirigía a /dashboard y llama a la función getcookie(s_role), saltaba el abort(401, "Sorry, access denied") que corresponde al "else" de esta función.

Ahora lo crea y después de registrarte inicia sesión automáticamente.